### PR TITLE
Add Docker support to make installation easier on systems with no recent gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc:4.9
+
+COPY . /usr/src/traveler
+WORKDIR /usr/src/traveler
+
+RUN \
+  cd /usr/src/traveler/src && \
+  make build
+
+ENV PATH /usr/src/traveler/bin:$PATH
+
+ENTRYPOINT ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ Use `git clone https://github.com/davidhoksza/traveler` to download project
 
 The binaries will be copied into traveler/bin. To navigate there from the src directory use: `cd ../bin`
 
+## Using with Docker
+
+1. Download the source code and `cd` into the traveler directory.
+
+2. Build an image:
+
+  ```
+  docker build . -t traveler
+  ```
+
+3. Run the container:
+
+  ```
+  docker run -v "$PWD":/data -it traveler
+  ```
+
+The `traveler` executable is available in the PATH, and the current directory is mounted in the container under `/data`.
+
 ## Usage:
 	traveler [-h|--help]
 	traveler [OPTIONS] <STRUCTURES>


### PR DESCRIPTION
Hi David!

I was going to play around with `traveler` but had some trouble installing it on my Mac or on the cluster because I didn't have the right gcc version, so I added support for running `traveler` with [Docker](https://www.docker.com). I thought you may find it useful too so I am sending a pull request.

I look forward to testing `traveler` some more in the next few days. I am hoping that it can be used to display RNA secondary structures in standard orientations in [RNAcentral](http://rnacentral.org). Thank you for developing this software!